### PR TITLE
edits to residual calculations

### DIFF
--- a/R/resid_fns.R
+++ b/R/resid_fns.R
@@ -1,7 +1,7 @@
 calculate.osa <- function(obj, methods, observation.name,
                           data.term.indicator='keep',
                           Range = c(-Inf,Inf), Discrete = NULL, 
-                          DiscreteSupport = NULL, Subset = NULL){
+                          Subset = NULL){
   ## OSA residuals
   fg <- osg <- cdf <- gen <- NA
   runtime.fg <- runtime.osg <- runtime.cdf <- runtime.gen <- NA
@@ -10,7 +10,7 @@ calculate.osa <- function(obj, methods, observation.name,
     fg <- tryCatch(
       oneStepPredict(obj, observation.name=observation.name,
                      method="fullGaussian", trace=FALSE,
-                     discrete = Discrete, discreteSupport = DiscreteSupport,
+                     discrete = Discrete,
                      subset = Subset)$residual,
       error=function(e) 'error')
     runtime.fg <- as.numeric(Sys.time()-t0, 'secs')
@@ -26,7 +26,7 @@ calculate.osa <- function(obj, methods, observation.name,
       oneStepPredict(obj, observation.name=observation.name,
                      data.term.indicator='keep' ,
                      method="oneStepGaussian", trace=FALSE,
-                     discrete = Discrete, discreteSupport = DiscreteSupport,
+                     discrete = Discrete, 
                      subset = Subset)$residual,
       error=function(e) 'error')
     runtime.osg <- as.numeric(Sys.time()-t0, 'secs')
@@ -42,7 +42,7 @@ calculate.osa <- function(obj, methods, observation.name,
       oneStepPredict(obj, observation.name=observation.name,
                      data.term.indicator='keep' ,
                      method="cdf", trace=FALSE,
-                     discrete = Discrete, discreteSupport = DiscreteSupport,
+                     discrete = Discrete, 
                      subset = Subset)$residual,
       error=function(e) 'error')
     runtime.cdf <- as.numeric(Sys.time()-t0, 'secs')
@@ -60,7 +60,7 @@ calculate.osa <- function(obj, methods, observation.name,
                      range = Range,
                      ##! range = c(0,Inf) only when obs>0 ,
                      method="oneStepGeneric", trace=FALSE,
-                     discrete = Discrete, discreteSupport = DiscreteSupport,
+                     discrete = Discrete, 
                      subset = Subset)$residual,
       error=function(e) 'error')
     runtime.gen <- as.numeric(Sys.time()-t0, 'secs')
@@ -218,7 +218,7 @@ calc.pvals <- function(type, method, mod, res.obj, version, fam, doTrue){
                                  sd=sd(res.obj[[method[m]]]), estimated = TRUE)$p.value
         }
         ks <- suppressWarnings(ks.test(res.obj[[method[m]]],'pnorm')$p.value)
-        df <- rbind(df, data.frame(type='osa', method=method[m], model=mod, test='GOF.ad', version = version, pvalue = ad))
+      #  df <- rbind(df, data.frame(type='osa', method=method[m], model=mod, test='GOF.ad', version = version, pvalue = ad))
         df <- rbind(df, data.frame(type='osa', method=method[m], model=mod, test='GOF.ks', version = version, pvalue = ks))
       }
     }
@@ -273,7 +273,7 @@ calc.pvals <- function(type, method, mod, res.obj, version, fam, doTrue){
         }
         ks <- suppressWarnings(ks.test(res.obj[[method[m]]]$out$scaledResiduals,'punif')$p.value)
     
-        df <- rbind(df, data.frame(type='sim', method=method[m], model=mod, test='GOF.ad', version = version, pvalue = ad))
+     #   df <- rbind(df, data.frame(type='sim', method=method[m], model=mod, test='GOF.ad', version = version, pvalue = ad))
         df <- rbind(df, data.frame(type='sim', method=method[m], model=mod, test='GOF.ks', version = version, pvalue = ks))
       }
     }

--- a/R/run_analysis.R
+++ b/R/run_analysis.R
@@ -29,16 +29,21 @@ packageVersion('DHARMa')                # 0.3.3.0
 reps <- 1:500
 
 do.true <- TRUE
+osa.methods <- c('fg', 'osg', 'gen', 'cdf')
+dharma.methods <- c('uncond', 'cond')
 
 ## Simple linear model as sanity check. Some resid methods not
 ## applicable b/c no random effects
+## possible mispecifications: 
 run_model(reps, mod='linmod', misp='overdispersion', do.true = do.true)
 ## Random walk from the paper
 run_model(reps, mod='randomwalk', misp='mu0', do.true = do.true)
 ## Andrea's simple GLMM with 5 groups
 run_model(reps, ng = 5, mod='simpleGLMM', misp='miss.cov', do.true = do.true)
-## ## Simple spatial SPDE model
-## run_model(reps, mod='spatial', misp='overdispersion', do.true = do.true)
+## Simple spatial SPDE model
+#Turn off generic method - takes too long
+osa.methods <- c('cdf') #only 'cdf' and 'gen' suitable for discrete distributions
+run_model(reps, mod='spatial', misp='overdispersion', do.true = do.true)
 
 
 pvals <- lapply(list.files('results', pattern='_pvals.RDS',


### PR DESCRIPTION
The following files and functions were edited:

R/run_analysis.R
- osa.methods and dharma.methods were moved here to turn them into global values
- spatial model run was turned on with only cdf method specified

R/model_fns.R/run_iter()
- turned off parcond
- moved methods to run_analysis.R
- fixed bug in oneStepGeneric calculation

R/resid_fns.R
- calc.osa(): removed discreteSupport option to fix bug in oneStepGeneric method
- calc.pvalues(): dropped AD test from results
